### PR TITLE
Fix formatting for 4.0

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,11 +49,11 @@ class slack (
       section => 'master',
       setting => 'reports',
       value   => $slack_puppet_reports,
-      require => File [ "${slack_puppet_dir}/slack.yaml"],
+      require => File[ "${slack_puppet_dir}/slack.yaml"],
       before  => Anchor['slack::end'],
     }
   }
   anchor{'slack::end':
-    require => File [ "${slack_puppet_dir}/slack.yaml"],
+    require => File[ "${slack_puppet_dir}/slack.yaml"],
   }
 }


### PR DESCRIPTION
4.0 was unhappy with the spacing before the '[' character. Removing the space from ' [' allows the puppet run to complete with module.
